### PR TITLE
Require the PSR packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,17 @@
         }
     ],
     "require": {
-        "php" : "^7.3 || ~8.0.0"
+        "php": "^7.3 || ~8.0.0",
+        "psr/container": "^1.0",
+        "psr/event-dispatcher": "^1.0",
+        "psr/log": "^1.1"
     },
     "extra": {
         "branch-alias": {
             "dev-master": "22.0.0-dev"
         }
+    },
+    "config": {
+        "sort-packages": true
     }
 }


### PR DESCRIPTION
Our container, event dispatcher and logger depend on the PSR interfaces
and therefore static analysis fails in some apps if the PSR packages are
not included through other peer/sub deps. This adds them here to have a
clean composer package.

@icewind1991 @rullzer @nickvergessen 