### PR TITLE
Require the PSR packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,16 @@
         }
     ],
     "require": {
-        "php" : "^7.3 || ~8.0.0"
+        "php": "^7.3 || ~8.0.0",
+        "psr/container": "^1.0",
+        "psr/log": "^1.1"
     },
     "extra": {
         "branch-alias": {
             "dev-master": "21.0.0-dev"
         }
+    },
+    "config": {
+        "sort-packages": true
     }
 }


### PR DESCRIPTION
Backport of https://github.com/ChristophWurst/nextcloud_composer/pull/7 but without the event-dispatcher that we didn't use yet.

@rullzer @nickvergessen 