### PR TITLE
Use GitHub Actions

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,0 +1,27 @@
+name: Update APIs
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    name: update
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Update
+        run: ./build.sh
+
+      - name: Check status
+        run: git status && git diff-index HEAD
+
+      - name: Push
+        run: ./push.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: php
-script:
-  - git checkout $TRAVIS_BRANCH
-  - ./build.sh
-  - git status
-  - git diff-index HEAD
-  - ./push.sh
-


### PR DESCRIPTION
https://travis-ci.org is not building anymore. This PR switches to using GitHub Actions to get the package updating again (feel free to close it if you'd rather just switch to using https://travis-ci.com).

![Screenshot 2021-07-01 at 21-04-36 ChristophWurst nextcloud_composer - Travis CI](https://user-images.githubusercontent.com/47195730/124207163-7777c200-db17-11eb-912b-14c2a9661025.png)
