### PR TITLE
Bump psr/container to ^1.1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.4 || ~8.0 || ~8.1",
-        "psr/container": "^1.0",
+        "psr/container": "^1.1.1",
         "psr/event-dispatcher": "^1.0",
         "psr/log": "^1.1"
     },


### PR DESCRIPTION
Fix CI errors in some dependent packages e.g. https://github.com/nextcloud/files_antivirus/pull/226

2.0.1 seems to be the latest [release](https://github.com/php-fig/container/releases) which still supports PHP 7.3 needed by apps which still support Nextcloud 21